### PR TITLE
fix various build warning (cause test failure on x86_64)

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -26,7 +26,7 @@ PHP_METHOD(protocolbuffers_enum, isValid)
 	return;
 #else
 	long value;
-	zval *result, *result2;
+	zval *result;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
 		"l", &value) == FAILURE) {
@@ -71,7 +71,7 @@ PHP_METHOD(protocolbuffers_enum, getName)
 	return;
 #else
 	long value;
-	zval *result, *result2;
+	zval *result;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
 		"l", &value) == FAILURE) {
@@ -79,7 +79,7 @@ PHP_METHOD(protocolbuffers_enum, getName)
 	}
 
 	if (zend_call_method_with_0_params(NULL, EG(called_scope), NULL, "getenumdescriptor", &result)) {
-		zval *values, **entry, **key;
+		zval *values, **entry;
 		HashPosition pos;
 
 		if (!instanceof_function_ex(Z_OBJCE_P(result), php_protocol_buffers_enum_descriptor_class_entry, 0 TSRMLS_CC)) {

--- a/enum_descriptor_builder.c
+++ b/enum_descriptor_builder.c
@@ -27,7 +27,7 @@ PHP_METHOD(protocolbuffers_enum_descriptor_builder, __construct)
 PHP_METHOD(protocolbuffers_enum_descriptor_builder, addValue)
 {
 	zval *instance = getThis();
-	zval *value, **fields, *name, *value2;
+	zval *value, **fields, *name;
 	zend_bool force = 0;
 	char *property;
 	int property_len;

--- a/helper.c
+++ b/helper.c
@@ -35,7 +35,7 @@ static void php_protocolbuffers_helper_debug_zval(zval **value TSRMLS_DC)
 	zval *val = *value;
 
 	php_printf("{\n");
-	php_printf("  address: 0x%x,\n", (unsigned int)val);
+	php_printf("  address: 0x%lx,\n", (unsigned long)val);
 	php_printf("  type: %d,\n", val->type);
 	php_printf("  is_ref: %d,\n", PZVAL_IS_REF(val));
 	php_printf("  refcount: %d,\n", Z_REFCOUNT_PP(value));
@@ -44,14 +44,14 @@ static void php_protocolbuffers_helper_debug_zval(zval **value TSRMLS_DC)
 	php_printf("    double: %f,\n", val->value.dval);
 	if (val->type == 4) {
 		php_printf("    ht: {\n");
-		php_printf("      address: 0x%x,\n", (unsigned int)val->value.ht);
+		php_printf("      address: 0x%lx,\n", (unsigned long)val->value.ht);
 		php_printf("      num_of_elements: %d,\n", (unsigned int)val->value.ht->nNumOfElements);
 		php_printf("      next_free_elements: %d,\n", (unsigned int)val->value.ht->nNextFreeElement);
 		php_printf("    },\n");
 	}
 	php_printf("    object: {\n");
 	php_printf("      handle: 0x%x,\n", val->value.obj.handle);
-	php_printf("      handlers: 0x%x,\n", (unsigned int)val->value.obj.handlers);
+	php_printf("      handlers: 0x%lx,\n", (unsigned long)val->value.obj.handlers);
 	php_printf("    },\n");
 	php_printf("  }\n");
 	php_printf("}\n");

--- a/json_serializer.c
+++ b/json_serializer.c
@@ -156,7 +156,7 @@ static int _json_serializer_sint64(
 }
 
 static int _json_serializer_fixed64(
-	int64_t value,
+	uint64_t value,
 	php_protocolbuffers_scheme *scheme,
 	php_protocolbuffers_scheme_container *container,
 	void *opaque TSRMLS_DC
@@ -403,7 +403,7 @@ static php_protocolbuffers_serializer2 json_serializer = {
 };
 
 
-static const char* php_protocolbuffers_get_property_name(php_protocolbuffers_scheme_container *container, php_protocolbuffers_scheme *scheme, size_t *name_len)
+static const char* php_protocolbuffers_get_property_name(php_protocolbuffers_scheme_container *container, php_protocolbuffers_scheme *scheme, int *name_len)
 {
 	const char *name;
 	if (container->use_single_property < 1) {
@@ -634,7 +634,7 @@ static int php_protocolbuffers_json_encode_value(zval **element, php_protocolbuf
 			int32_t v;
 
 			zval_copy_ctor(&value_copy);
-			convert_to_int64(&value_copy, &v);
+			convert_to_int32(&value_copy, &v);
 			ser->serialize_sfixed32(v, scheme, container, outer TSRMLS_CC);
 			zval_dtor(&value_copy);
 			break;
@@ -751,13 +751,13 @@ int php_protocolbuffers_fetch_element2(php_protocolbuffers_scheme_container *con
 
 	if (zend_hash_find(hash, name, name_len, (void **)&tmp) == SUCCESS) {
 		*output = *tmp;
-		return 0;
 	} else {
 		if (scheme->required > 0) {
 			php_protocolbuffers_raise_error_or_exception(php_protocol_buffers_invalid_protocolbuffers_exception_class_entry, E_WARNING, 0, "the class does not declared required property `%s`. probably you missed declaration", scheme->name);
 			return 1;
 		}
 	}
+	return 0;
 }
 
 
@@ -768,7 +768,6 @@ int php_protocolbuffers_encode_jsonserialize(zval *klass, php_protocolbuffers_sc
 	HashTable *hash = NULL;
 	zval **c = NULL;
 	zval *target = *result;
-	php_protocolbuffers_serializer2 *ser = &json_serializer;
 
 	if (container->use_single_property < 1) {
 		hash = Z_OBJPROP_P(klass);

--- a/message.c
+++ b/message.c
@@ -1571,7 +1571,6 @@ PHP_METHOD(protocolbuffers_message, clearExtension)
 
 	if (zend_hash_find(htt, n, n_len, (void **)&e) == SUCCESS) {
 		zval *tmp;
-		ulong hval;
 		if (is_mangled) {
 			efree(n);
 		}
@@ -1676,7 +1675,6 @@ PHP_METHOD(protocolbuffers_message, jsonSerialize)
 PHP_METHOD(protocolbuffers_message, toArray)
 {
 	zval *instance = getThis(), *result = NULL;
-	zend_class_entry **json;
 
 	if (php_protocolbuffers_jsonserialize(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1, Z_OBJCE_P(instance), instance, &result) == 0) {
 		RETURN_ZVAL(result, 0, 1);

--- a/serializer.c
+++ b/serializer.c
@@ -723,13 +723,13 @@ int php_protocolbuffers_fetch_element(INTERNAL_FUNCTION_PARAMETERS, php_protocol
 
 	if (zend_hash_find(hash, name, name_len, (void **)&tmp) == SUCCESS) {
 		*output = *tmp;
-		return 0;
 	} else {
 		if (scheme->required > 0) {
 			zend_throw_exception_ex(php_protocol_buffers_invalid_protocolbuffers_exception_class_entry, 0 TSRMLS_CC, "the class does not declared required property `%s`. probably you missed declaration", scheme->name);
 			return 1;
 		}
 	}
+	return 0;
 }
 
 int php_protocolbuffers_encode_message(INTERNAL_FUNCTION_PARAMETERS, zval *klass, php_protocolbuffers_scheme_container *container, php_protocolbuffers_serializer **serializer)

--- a/unknown_field_set.c
+++ b/unknown_field_set.c
@@ -66,7 +66,7 @@ void php_protocolbuffers_unknown_field_set_properties_init(zval *object TSRMLS_D
 
 void php_protocolbuffers_unknown_field_clear(INTERNAL_FUNCTION_PARAMETERS, zval *instance)
 {
-	zval *fields = NULL, **prior_fields = NULL;
+	zval *fields = NULL;
 	char *name = {0};
 	int name_len = 0;
 


### PR DESCRIPTION
At least the call to convert_to_int64/convert_to_int32 cause memory corruption and various test failed.

I still have a tests/600_extension_clear.phpt failing (only during "make test", not on manual work... I'm working on it)
