### PR TITLE
Fixed an error message about required property

### DIFF
--- a/json_serializer.c
+++ b/json_serializer.c
@@ -711,7 +711,7 @@ static void php_protocolbuffers_json_encode_element(php_protocolbuffers_scheme_c
 			}
 		} else {
 			if (scheme->required > 0 && Z_TYPE_PP(tmp) == IS_NULL) {
-				php_protocolbuffers_raise_error_or_exception(php_protocol_buffers_uninitialized_message_exception_class_entry, E_WARNING, throws_exception, "the class does not have required property `%s`.", scheme->name);
+				php_protocolbuffers_raise_error_or_exception(php_protocol_buffers_uninitialized_message_exception_class_entry, E_WARNING, throws_exception, "the class does have required property `%s`.", scheme->name);
 				return;
 			}
 			if (scheme->required == 0 && Z_TYPE_PP(tmp) == IS_NULL) {

--- a/php_protocolbuffers.h
+++ b/php_protocolbuffers.h
@@ -32,7 +32,7 @@
 #define PHP_PROTOCOLBUFFERS_H
 
 #define PHP_PROTOCOLBUFFERS_EXTNAME "protocolbuffers"
-#define PHP_PROTOCOLBUFFERS_VERSION "0.2.5"
+#define PHP_PROTOCOLBUFFERS_VERSION "0.2.6"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/serializer.c
+++ b/serializer.c
@@ -558,7 +558,7 @@ static void php_protocolbuffers_encode_element(INTERNAL_FUNCTION_PARAMETERS, php
 				php_error_docref(NULL TSRMLS_CC, E_ERROR, "php_protocolbuffers_encode_element_packed called non repeated scheme. this is bug");
 			} else {
 				if (scheme->required > 0 && Z_TYPE_PP(tmp) == IS_NULL) {
-					zend_throw_exception_ex(php_protocol_buffers_uninitialized_message_exception_class_entry, 0 TSRMLS_CC, "the class does not have required property `%s`.", scheme->name);
+					zend_throw_exception_ex(php_protocol_buffers_uninitialized_message_exception_class_entry, 0 TSRMLS_CC, "the class does have required property `%s`.", scheme->name);
 					return;
 				}
 				if (scheme->required == 0 && Z_TYPE_PP(tmp) == IS_NULL) {


### PR DESCRIPTION
Hi there!

I've fixed an error message about required property. 
1) There is a data structure:

```
message Person {
     required uint32 person_id = 1;
}
```

2) Example of using:

``` php
<?php

require "autoload.php";

$person = new \Person();
var_dump($person->serializeToString());
```

There was error: "the class does not have required property `person_id`" , but he does.
