### PR TITLE
fix php_protocolbuffers_parse_magic_method

### DIFF
--- a/message.c
+++ b/message.c
@@ -877,11 +877,12 @@ static enum ProtocolBuffers_MagicMethod php_protocolbuffers_parse_magic_method(c
 
 		if (name[i] >= 'A' && name[i] <= 'Z') {
 			if (buf->len > 0) {
-				if ((last_is_capital == 0
-					&& i+1 >= name_len)
-					|| (i+1 < name_len && name[i+1] >= 'a' && name[i+1] <= 'z')) {
-					smart_str_appendc(buf, '_');
-				}
+//				if ((last_is_capital == 0
+//					&& i+1 >= name_len)
+//					|| (i+1 < name_len && name[i+1] >= 'a' && name[i+1] <= 'z')) {
+//					smart_str_appendc(buf, '_');
+//				}
+                smart_str_appendc(buf, '_');
 			}
 			smart_str_appendc(buf, name[i] + ('a' - 'A'));
 			smart_str_appendc(buf2, name[i]);

--- a/message.c
+++ b/message.c
@@ -882,7 +882,7 @@ static enum ProtocolBuffers_MagicMethod php_protocolbuffers_parse_magic_method(c
 //					|| (i+1 < name_len && name[i+1] >= 'a' && name[i+1] <= 'z')) {
 //					smart_str_appendc(buf, '_');
 //				}
-                smart_str_appendc(buf, '_');
+				smart_str_appendc(buf, '_');
 			}
 			smart_str_appendc(buf, name[i] + ('a' - 'A'));
 			smart_str_appendc(buf2, name[i]);


### PR DESCRIPTION
If the field is defined as "optional uint32 xxx_y_zzz", than the magic method in php file must be called as "getXxx_YZzz(), setXxx_YZzz()".
This PR will fix that bug. 
Best wishes.